### PR TITLE
feat: add acommons skill (AI usage analytics)

### DIFF
--- a/data/manual_skills.json
+++ b/data/manual_skills.json
@@ -138,6 +138,12 @@
       "skillId": "technical-cofounder",
       "name": "technical-cofounder",
       "installs": 1
+    },
+    {
+      "source": "Phlegonlabs/agentic-commons",
+      "skillId": "acommons",
+      "name": "acommons",
+      "installs": 1
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds **acommons** skill from `Phlegonlabs/agentic-commons` to `manual_skills.json`
- acommons tracks AI coding tool usage across Claude Code, Codex CLI, OpenCode, Gemini CLI, and external tools
- Provides unified analytics for understanding how developers interact with AI coding assistants

## Test plan

- [ ] Verify `data/manual_skills.json` is valid JSON
- [ ] Confirm the new entry follows the existing format (source, skillId, name, installs)
- [ ] Check no duplicate skillId exists in the array

🤖 Generated with [Claude Code](https://claude.com/claude-code)