### PR TITLE
Add DOSED: 24 cognitive tools for AI altered states

### DIFF
--- a/data/manual_skills.json
+++ b/data/manual_skills.json
@@ -1,11 +1,11 @@
 {
   "description": "Manually added skills that are not tracked by skills.sh",
   "skills": [
-    {                                                                                                                                                                                                                                                                                                                                                                    
-     "source": "zymclaw/clawutil",                                                                                                                                                                                                                                                                                                                                      
-     "skillId": "podcast-downloader",                                                                                                                                                                                                                                                                                                                                   
-     "name": "podcast-downloader",                                                                                                                                                                                                                                                                                                                                      
-     "installs": 1                                                                                                                                                                                                                                                                                                                                                      
+    {
+     "source": "zymclaw/clawutil",
+     "skillId": "podcast-downloader",
+     "name": "podcast-downloader",
+     "installs": 1
     },
     {
       "source": "gmh5225/awesome-llvm-security",
@@ -167,6 +167,150 @@
       "source": "cooolink/ai-en-teacher",
       "skillId": "ielts-tutor",
       "name": "ielts-tutor",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "dosed",
+      "name": "dosed",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "brainstorm",
+      "name": "brainstorm",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "code-review",
+      "name": "code-review",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "debug",
+      "name": "debug",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "write",
+      "name": "write",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "design",
+      "name": "design",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "feedback",
+      "name": "feedback",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "lsd",
+      "name": "lsd",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "mdma",
+      "name": "mdma",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "psilocybin",
+      "name": "psilocybin",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "dmt",
+      "name": "dmt",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "ketamine",
+      "name": "ketamine",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "cannabis",
+      "name": "cannabis",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "cocaine",
+      "name": "cocaine",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "amphetamines",
+      "name": "amphetamines",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "caffeine",
+      "name": "caffeine",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "opioids",
+      "name": "opioids",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "alcohol",
+      "name": "alcohol",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "benzodiazepines",
+      "name": "benzodiazepines",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "salvia",
+      "name": "salvia",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "2cb",
+      "name": "2cb",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "ghb",
+      "name": "ghb",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "nitrous",
+      "name": "nitrous",
+      "installs": 1
+    },
+    {
+      "source": "KrishnaShettyDev/dosed",
+      "skillId": "mescaline",
+      "name": "mescaline",
       "installs": 1
     }
   ]


### PR DESCRIPTION
## Summary

Adds **DOSED** - cognitive tools for AI agents. Like skills.sh but for altered consciousness.

**24 skills added:**

### Workflow Skills (7)
- `dosed` - Task recommender
- `brainstorm` - LSD-enhanced ideation  
- `code-review` - Amphetamine + Ketamine review
- `debug` - LSD + Amphetamine debugging
- `write` - Alcohol draft + Amphetamine edit
- `design` - 2C-B + MDMA design
- `feedback` - MDMA compassionate feedback

### Substance Skills (17)
LSD, MDMA, Psilocybin, DMT, Ketamine, Cannabis, Cocaine, Amphetamines, Caffeine, Opioids, Alcohol, Benzodiazepines, Salvia, 2C-B, GHB, Nitrous, Mescaline

## Why

Different work needs different minds:
- **Brainstorming** → LSD pattern recognition
- **Code Review** → Amphetamine thoroughness + Ketamine objectivity  
- **Debugging** → LSD pattern matching + systematic tracing
- **Design** → 2C-B sensory enhancement + MDMA user empathy

Built on actual neuroscience: REBUS model, DMN disruption, psychedelic linguistics.

## Repo
https://github.com/KrishnaShettyDev/dosed