### PR TITLE
Add ilyautov/humanizer-ru to manual skills

### DIFF
--- a/data/manual_skills.json
+++ b/data/manual_skills.json
@@ -2,6 +2,12 @@
     "description": "Manually added skills that are not tracked by skills.sh",
     "skills": [
         {
+            "source": "ilyautov/humanizer-ru",
+            "skillId": "humanizer-ru",
+            "name": "humanizer-ru",
+            "installs": 1
+        },
+        {
             "source": "zymclaw/clawutil",
             "skillId": "podcast-downloader",
             "name": "podcast-downloader",


### PR DESCRIPTION
Adds [ilyautov/humanizer-ru](https://github.com/ilyautov/humanizer-ru) to `data/manual_skills.json` per the documented path for skills not yet in the skills.sh top list.

humanizer-ru is an open-source Claude/agent skill (SKILL.md) that removes AI-writing tells from Russian text (bureaucratese, English calques, ChatGPT/Claude fingerprints): 52 patterns, a deterministic offline scanner with a 0-100 cleanliness score, MIT. Available via `npx skills add ilyautov/humanizer-ru`.

Disclosure: I am the author.