### PR TITLE
Add yylo-dev/yylo-skills to manual skills

### DIFF
--- a/data/manual_skills.json
+++ b/data/manual_skills.json
@@ -330,6 +330,48 @@
             "skillId": "press-release",
             "name": "press-release",
             "installs": 1
+        },
+        {
+            "source": "yylo-dev/yylo-skills",
+            "skillId": "artifact-yylo",
+            "name": "artifact-yylo",
+            "installs": 1
+        },
+        {
+            "source": "yylo-dev/yylo-skills",
+            "skillId": "ledger-tasks-yylo",
+            "name": "ledger-tasks-yylo",
+            "installs": 1
+        },
+        {
+            "source": "yylo-dev/yylo-skills",
+            "skillId": "plan-ledger-tasks-yylo",
+            "name": "plan-ledger-tasks-yylo",
+            "installs": 1
+        },
+        {
+            "source": "yylo-dev/yylo-skills",
+            "skillId": "ralph-loop-yylo",
+            "name": "ralph-loop-yylo",
+            "installs": 1
+        },
+        {
+            "source": "yylo-dev/yylo-skills",
+            "skillId": "understand-project-yylo",
+            "name": "understand-project-yylo",
+            "installs": 1
+        },
+        {
+            "source": "yylo-dev/yylo-skills",
+            "skillId": "wiki-yylo",
+            "name": "wiki-yylo",
+            "installs": 1
+        },
+        {
+            "source": "yylo-dev/yylo-skills",
+            "skillId": "workflow-yylo",
+            "name": "workflow-yylo",
+            "installs": 1
         }
     ]
 }


### PR DESCRIPTION
Adds [yylo-dev/yylo-skills](https://github.com/yylo-dev/yylo-skills) to `data/manual_skills.json` per the documented path for skills not tracked by skills.sh — 7 skills in one pack, each resolving at `skills/<skillId>/SKILL.md` on `main`:

- **ledger-tasks-yylo** — task management for the YYLO Ledger board (create/list/search/update/deps/merge workflows)
- **plan-ledger-tasks-yylo** — turn a request into a Product Development Requirement plus implementation-sized Ledger tasks
- **ralph-loop-yylo** — execute exactly one assigned Ledger task through the Ralph loop to a validated queued commit
- **understand-project-yylo** — inspect product architecture, dependencies, and validation loops before planning a change
- **workflow-yylo** — create and maintain validated workflow Records with storage/execution/evidence boundaries
- **artifact-yylo** — capture and retrieve durable artifact Records as immutable, secret-safe evidence
- **wiki-yylo** — durable project knowledge as wiki Records with revision-safe Markdown updates

YYLO is an MIT-licensed command-line orchestrator for coding agents (works with Claude Code, Codex, Pi and similar CLIs); the pack installs via `npx skills add yylo-dev/yylo-skills --skill <skillId>`.

Two housekeeping notes, happy to adjust:
1. The crawler's cache at `data/skills-md/yylo-dev/yylo-skills/` holds a 2026-09-09 snapshot under the pack's pre-rename skill IDs (`kanban-workflow`, `plan-kanban-tasks`, `ralph-loop`, `understand-project`) — the repo renamed its skills to the `-yylo` suffixes and added three more that same day, so those cached entries no longer resolve upstream. I left the cache untouched since the crawler owns it; the manual entries above reference the current live IDs.
2. `installs: 1` per the documented minimum.

Disclosure: I am part of the YYLO team; this PR was prepared with AI assistance. Happy to reformat, trim to a subset, or drop it entirely if any entry doesn't fit the curation bar.